### PR TITLE
Add required header for ostream operations

### DIFF
--- a/k3dsdk/measurement.h
+++ b/k3dsdk/measurement.h
@@ -27,6 +27,7 @@
 
 #include <cassert>
 #include <iosfwd>
+#include <ostream>
 #include <map>
 #include <string>
 #include <typeinfo>


### PR DESCRIPTION
This file uses std::ostream::operator<<(double) without including
<ostream> and so fails to compile using GCC 7.